### PR TITLE
Portability fixes for Cygwin.

### DIFF
--- a/src/codegen.c
+++ b/src/codegen.c
@@ -1,3 +1,6 @@
+/* enables `strdup(3)` on Cygwin, probably other systems */
+#define _GNU_SOURCE 1
+
 #include "codegen.h"
 #include "ast.h"
 #include "string_literals.h"
@@ -10,10 +13,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-
-#if __linux__
-#define strdup strdupc
-#endif
 
 // External declarations from type_checker.c
 extern TypeInfo* getTypeInfo(const char* name);
@@ -530,7 +529,7 @@ void generateFunction(ASTNode* node) {
         
         // Replace invalid characters with underscore
         for (char* c = prefix; *c; c++) {
-            if (!isalnum(*c) && *c != '_') {
+            if (!isalnum((int)*c) && *c != '_') {
                 *c = '_';
             }
         }
@@ -687,7 +686,7 @@ void generateStatement(ASTNode* node) {
                         char* dot = strrchr(prefix, '.');
                         if (dot) *dot = '\0';
                         for (char* c = prefix; *c; c++) {
-                            if (!isalnum(*c) && *c != '_') {
+                            if (!isalnum((int)*c) && *c != '_') {
                                 *c = '_';
                             }
                         }
@@ -790,7 +789,7 @@ void generateStatement(ASTNode* node) {
                         char* dot = strrchr(prefix, '.');
                         if (dot) *dot = '\0';
                         for (char* c = prefix; *c; c++) {
-                            if (!isalnum(*c) && *c != '_') {
+                            if (!isalnum((int)*c) && *c != '_') {
                                 *c = '_';
                             }
                         }
@@ -934,7 +933,7 @@ void generateVariableDeclaration(ASTNode* node) {
             char* dot = strrchr(prefix, '.');
             if (dot) *dot = '\0';
             for (char* c = prefix; *c; c++) {
-                if (!isalnum(*c) && *c != '_') {
+                if (!isalnum((int)*c) && *c != '_') {
                     *c = '_';
                 }
             }
@@ -1226,7 +1225,7 @@ void generateExpression(ASTNode* node) {
                         char* dot = strrchr(prefix, '.');
                         if (dot) *dot = '\0';
                         for (char* c = prefix; *c; c++) {
-                            if (!isalnum(*c) && *c != '_') {
+                            if (!isalnum((int)*c) && *c != '_') {
                                 *c = '_';
                             }
                         }
@@ -1293,7 +1292,7 @@ void generateExpression(ASTNode* node) {
                     if (prefix) {
                         strcpy(prefix, filename);
                         char* dot = strrchr(prefix, '.'); if (dot) *dot = '\0';
-                        for (char* c = prefix; *c; c++) if (!isalnum(*c) && *c != '_') *c = '_';
+                        for (char* c = prefix; *c; c++) if (!isalnum((int)*c) && *c != '_') *c = '_';
                     }                    // Determine if this global is an array
                     TypeInfo* tinfo = getTypeInfo(node->identifier);
                     if (tinfo && tinfo->is_array) {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -34,7 +34,7 @@ void initLexer(const char* src) {
 static void skipWhitespace() {
     while (source[position]) {
         // Skip spaces, tabs, newlines
-        if (isspace(source[position])) {
+        if (isspace((int)source[position])) {
             if (source[position] == '\n') {
                 line++;
                 column = 1;
@@ -123,11 +123,11 @@ Token getNextToken() {
     }
 
     // Handle keywords and identifiers
-    if (isalpha(source[position]) || source[position] == '_') {
+    if (isalpha((int)source[position]) || source[position] == '_') {
         size_t start = position;
         int startColumn = column;
         
-        while (isalnum(source[position]) || source[position] == '_') {
+        while (isalnum((int)source[position]) || source[position] == '_') {
             position++;
             column++;
         }
@@ -145,7 +145,7 @@ Token getNextToken() {
     }
 
     // Handle numbers
-    if (isdigit(source[position])) {
+    if (isdigit((int)source[position])) {
         size_t start = position;
         int startColumn = column;
         
@@ -153,13 +153,13 @@ Token getNextToken() {
         if (source[position] == '0' && (source[position + 1] == 'x' || source[position + 1] == 'X')) {
             position += 2;
             column += 2;
-            while (isxdigit(source[position])) {
+            while (isxdigit((int)source[position])) {
                 position++;
                 column++;
             }
         } else {
             // Regular decimal numbers
-            while (isdigit(source[position])) {
+            while (isdigit((int)source[position])) {
                 position++;
                 column++;
             }
@@ -235,7 +235,7 @@ Token getNextToken() {
                 case '"':  charValue = '"';  break;
                 case 'x': {
                     // Handle hex escape sequence \xHH
-                    if (isxdigit(source[position + 1]) && isxdigit(source[position + 2])) {
+                    if (isxdigit((int)source[position + 1]) && isxdigit((int)source[position + 2])) {
                         char hex[3] = {source[position + 1], source[position + 2], '\0'};
                         charValue = (char)strtol(hex, NULL, 16);
                         position += 2;

--- a/src/main.c
+++ b/src/main.c
@@ -106,8 +106,8 @@ int main(int argc, char* argv[]) {
                 addIncludePath(argv[++i]);
             }
         } else if (strncmp(argv[i], "-O", 2) == 0) {
-            if (isdigit(argv[i][2])) optimizationLevel = argv[i][2] - '0';
-            else if (i + 1 < argc && isdigit(argv[i+1][0])) optimizationLevel = argv[++i][0] - '0';
+            if (isdigit((int)argv[i][2])) optimizationLevel = argv[i][2] - '0';
+            else if (i + 1 < argc && isdigit((int)argv[i+1][0])) optimizationLevel = argv[++i][0] - '0';
         } else if ((strcmp(argv[i], "-disp") == 0 || strcmp(argv[i], "-DISP") == 0) && i + 1 < argc) {
             originAddress = (unsigned int)strtoul(argv[++i], NULL, 0);
         } else if (strcmp(argv[i], "-com") == 0 || strcmp(argv[i], "-COM") == 0) {

--- a/src/preprocessor.c
+++ b/src/preprocessor.c
@@ -137,10 +137,10 @@ static char* extractMacroName(const char* line, int* pos) {
     int len = 0;
     
     // Skip leading whitespace
-    while (isspace(line[*pos])) (*pos)++;
+    while (isspace((int)line[*pos])) (*pos)++;
     
     // Extract identifier (macro name)
-    while (isalnum(line[*pos]) || line[*pos] == '_') {
+    while (isalnum((int)line[*pos]) || line[*pos] == '_') {
         if (len < MAX_MACRO_NAME_LEN - 1) {
             buffer[len++] = line[*pos];
         }
@@ -157,7 +157,7 @@ static char* extractMacroValue(const char* line, int* pos) {
     int len = 0;
     
     // Skip leading whitespace
-    while (isspace(line[*pos])) (*pos)++;
+    while (isspace((int)line[*pos])) (*pos)++;
     
     // Extract the rest of the line as the value
     while (line[*pos] && line[*pos] != '\n' && line[*pos] != '\r') {
@@ -168,7 +168,7 @@ static char* extractMacroValue(const char* line, int* pos) {
     }
     
     // Remove trailing whitespace
-    while (len > 0 && isspace(buffer[len-1])) {
+    while (len > 0 && isspace((int)buffer[len-1])) {
         len--;
     }
     
@@ -264,7 +264,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
     pos++;
     
     // Skip any whitespace after the '#'
-    while (isspace(line[pos])) pos++;
+    while (isspace((int)line[pos])) pos++;
     
     // Debug output for directive processing
     #ifdef DEBUG_PREPROCESSOR
@@ -272,7 +272,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
     #endif
     
     // Determine directive type
-    if (strncmp(line + pos, "define", 6) == 0 && isspace(line[pos+6])) {
+    if (strncmp(line + pos, "define", 6) == 0 && isspace((int)line[pos+6])) {
         // #define directive
         pos += 6;  // Skip "define"
         
@@ -294,7 +294,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
             defineMacro(macroName, macroValue);
         }
     } 
-    else if (strncmp(line + pos, "undef", 5) == 0 && isspace(line[pos+5])) {
+    else if (strncmp(line + pos, "undef", 5) == 0 && isspace((int)line[pos+5])) {
         // #undef directive
         pos += 5;  // Skip "undef"
         
@@ -320,7 +320,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
             }
         }
     } 
-    else if (strncmp(line + pos, "ifdef", 5) == 0 && isspace(line[pos+5])) {
+    else if (strncmp(line + pos, "ifdef", 5) == 0 && isspace((int)line[pos+5])) {
         // #ifdef directive
         pos += 5;  // Skip "ifdef"
         (*ifLevel)++;
@@ -348,7 +348,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
             #endif
         }
     } 
-    else if (strncmp(line + pos, "ifndef", 6) == 0 && isspace(line[pos+6])) {
+    else if (strncmp(line + pos, "ifndef", 6) == 0 && isspace((int)line[pos+6])) {
         // #ifndef directive
         pos += 6;  // Skip "ifndef"
         (*ifLevel)++;
@@ -376,7 +376,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
             #endif
         }
     } 
-    else if (strncmp(line + pos, "if", 2) == 0 && isspace(line[pos+2])) {
+    else if (strncmp(line + pos, "if", 2) == 0 && isspace((int)line[pos+2])) {
         // #if directive
         pos += 2;  // Skip "if"
         (*ifLevel)++;
@@ -391,7 +391,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
         
         // Skip whitespace
-        while (isspace(line[pos])) pos++;
+        while (isspace((int)line[pos])) pos++;
         
         // Extract and evaluate the condition
         const char* expr = line + pos;
@@ -409,7 +409,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
     } 
     else if (strncmp(line + pos, "else", 4) == 0 && 
-             (isspace(line[pos+4]) || line[pos+4] == '\0' || line[pos+4] == '\n' || line[pos+4] == '\r')) {
+             (isspace((int)line[pos+4]) || line[pos+4] == '\0' || line[pos+4] == '\n' || line[pos+4] == '\r')) {
         // #else directive
         #ifdef DEBUG_PREPROCESSOR
         fprintf(stderr, "  Processing #else directive\n");
@@ -431,7 +431,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
     } 
     else if (strncmp(line + pos, "endif", 5) == 0 && 
-             (isspace(line[pos+5]) || line[pos+5] == '\0' || line[pos+5] == '\n' || line[pos+5] == '\r')) {
+             (isspace((int)line[pos+5]) || line[pos+5] == '\0' || line[pos+5] == '\n' || line[pos+5] == '\r')) {
         // #endif directive
         #ifdef DEBUG_PREPROCESSOR
         fprintf(stderr, "  Processing #endif (ifLevel=%d, skipLevel=%d)\n", *ifLevel, *skipLevel);
@@ -458,7 +458,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         fprintf(stderr, "  New ifLevel=%d, skipLevel=%d\n", *ifLevel, *skipLevel);
         #endif
     }
-    else if (strncmp(line + pos, "org", 3) == 0 && isspace(line[pos+3])) {
+    else if (strncmp(line + pos, "org", 3) == 0 && isspace((int)line[pos+3])) {
         // #org directive (custom extension to set origin address)
         pos += 3;  // Skip "org"
         
@@ -471,7 +471,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
         
         // Skip whitespace
-        while (isspace(line[pos])) pos++;
+        while (isspace((int)line[pos])) pos++;
         
         // Extract value (hexadecimal or decimal)
         char* orgValue = extractMacroValue(line, &pos);
@@ -483,7 +483,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         // Define a macro that can be used by code generator
         defineMacro("__ORG_ADDRESS__", orgValue);
     }
-    else if (strncmp(line + pos, "include", 7) == 0 && isspace(line[pos+7])) {
+    else if (strncmp(line + pos, "include", 7) == 0 && isspace((int)line[pos+7])) {
         // #include directive
         pos += 7;  // Skip "include"
         
@@ -496,7 +496,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
         
         // Skip whitespace
-        while (isspace(line[pos])) pos++;
+        while (isspace((int)line[pos])) pos++;
         
         // Determine include style (< > for system, " " for local)
         int isSystemHeader = 0;
@@ -561,7 +561,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         // by the calling function
         free(includedContent);
     }
-    else if (strncmp(line + pos, "pragma", 6) == 0 && isspace(line[pos+6])) {
+    else if (strncmp(line + pos, "pragma", 6) == 0 && isspace((int)line[pos+6])) {
         pos += 6;  // Skip "pragma"
         
         // Don't process if skipping code in a false condition block
@@ -573,7 +573,7 @@ static void processDirective(const char* line, int* ifLevel, int* skipLevel, con
         }
         
         // Skip whitespace
-        while (isspace(line[pos])) pos++;
+        while (isspace((int)line[pos])) pos++;
         
         // Check for "once" directive
         if (strncmp(line + pos, "once", 4) == 0) {
@@ -684,7 +684,7 @@ char* preprocessSource(const char* source) {
                 
                 // Gather the entire identifier
                 size_t j = i + 1;
-                while (source[j] && (isalnum(source[j]) || source[j] == '_')) {
+                while (source[j] && (isalnum((int)source[j]) || source[j] == '_')) {
                     if (identLen < MAX_MACRO_NAME_LEN - 1) {
                         identBuffer[identLen++] = source[j];
                     }

--- a/src/preprocessor_expr.c
+++ b/src/preprocessor_expr.c
@@ -12,7 +12,7 @@ static int evaluateFactor(const char** expr);
 
 // Skip whitespace in an expression
 static void skipWhitespace(const char** expr) {
-    while (**expr && isspace(**expr)) {
+    while (**expr && isspace((int)**expr)) {
         (*expr)++;
     }
 }
@@ -32,7 +32,7 @@ static int evaluateDefinedOperator(const char** expr) {
     char macroName[MAX_MACRO_NAME_LEN];
     int nameLen = 0;
     
-    while (**expr && (isalnum(**expr) || **expr == '_')) {
+    while (**expr && (isalnum((int)**expr) || **expr == '_')) {
         if (nameLen < MAX_MACRO_NAME_LEN - 1) {
             macroName[nameLen++] = **expr;
         }
@@ -113,10 +113,10 @@ static int parseNumber(const char** expr) {
     
     // Parse the number
     while (1) {
-        if (base == 10 && isdigit(**expr)) {
+        if (base == 10 && isdigit((int)**expr)) {
             value = value * 10 + (**expr - '0');
             (*expr)++;
-        } else if (base == 16 && isxdigit(**expr)) {
+        } else if (base == 16 && isxdigit((int)**expr)) {
             char c = tolower(**expr);
             if (isdigit(c)) {
                 value = value * 16 + (c - '0');
@@ -146,20 +146,20 @@ static int evaluateFactor(const char** expr) {
             fprintf(stderr, "Error: Missing closing parenthesis in expression\n");
         }
         return value;
-    } else if (isdigit(**expr)) {
+    } else if (isdigit((int)**expr)) {
         return parseNumber(expr);
-    } else if (strncmp(*expr, "defined", 7) == 0 && (isspace((*expr)[7]) || (*expr)[7] == '(')) {
+    } else if (strncmp(*expr, "defined", 7) == 0 && (isspace((int)(*expr)[7]) || (*expr)[7] == '(')) {
         (*expr) += 7;
         return evaluateDefinedOperator(expr);
-    } else if (strncmp(*expr, "sizeof", 6) == 0 && (isspace((*expr)[6]) || (*expr)[6] == '(')) {
+    } else if (strncmp(*expr, "sizeof", 6) == 0 && (isspace((int)(*expr)[6]) || (*expr)[6] == '(')) {
         (*expr) += 6;
         return evaluateSizeofOperator(expr);
-    } else if (isalpha(**expr) || **expr == '_') {
+    } else if (isalpha((int)**expr) || **expr == '_') {
         // Identifiers are treated as macros
         char macroName[MAX_MACRO_NAME_LEN];
         int nameLen = 0;
         
-        while (**expr && (isalnum(**expr) || **expr == '_')) {
+        while (**expr && (isalnum((int)**expr) || **expr == '_')) {
             if (nameLen < MAX_MACRO_NAME_LEN - 1) {
                 macroName[nameLen++] = **expr;
             }

--- a/src/string_literals.c
+++ b/src/string_literals.c
@@ -36,7 +36,7 @@ char* getSanitizedFilenamePrefix() {
     
     // Replace invalid characters with underscore
     for (char* c = prefix; *c; c++) {
-        if (!isalnum(*c) && *c != '_') {
+        if (!isalnum((int)*c) && *c != '_') {
             *c = '_';
         }
     }


### PR DESCRIPTION
The bulk of the changes here are converting all calls where a `char` is passed to `isalpha`/`isalnum`/`isspace`/etc to an `int` cast, since char may have an incompatible sign.
I'm pretty sure the strdupc definition isn't needed to silence that warning anymore with this commit, but if not, let me know and I'll add it back and force push.